### PR TITLE
More API client options

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,9 +89,12 @@ eu3.sec-tunnel.com,77.111.244.22,443
 
 | Argument | Type | Description |
 | -------- | ---- | ----------- |
-| api-address | String | override IP address of api.sec-tunnel.com |
+| api-address | String | override IP address of api2.sec-tunnel.com |
+| api-client-type | String | client type reported to SurfEasy API (default "se0316") |
+| api-client-version | String | client version reported to SurfEasy API (default "Stable 114.0.5282.21") |
 | api-login | String | SurfEasy API login (default "se0316") |
 | api-password | String | SurfEasy API password (default "SILrMEPBmJuhomxWkfm3JalqHX2Eheg1YhlEZiMh8II") |
+| api-user-agent | String | user agent reported to SurfEasy API (default "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 OPR/114.0.0.0") |
 | bind-address | String | HTTP proxy listen address (default "127.0.0.1:18080") |
 | bootstrap-dns | String | Comma-separated list of DNS/DoH/DoT/DoQ resolvers for initial discovery of SurfEasy API address. See https://github.com/ameshkov/dnslookup/ for upstream DNS URL format. Examples: `https://1.1.1.1/dns-query`, `quic://dns.adguard.com`  (default `https://1.1.1.3/dns-query,https://8.8.8.8/dns-query,https://dns.google/dns-query,https://security.cloudflare-dns.com/dns-query,https://wikimedia-dns.org/dns-query,https://dns.adguard-dns.com/dns-query,https://dns.quad9.net/dns-query,https://doh.cleanbrowsing.org/doh/adult-filter/`) |
 | cafile | String | use custom CA certificate bundle file |

--- a/main.go
+++ b/main.go
@@ -89,6 +89,9 @@ type CLIArgs struct {
 	apiLogin            string
 	apiPassword         string
 	apiAddress          string
+	apiClientType       string
+	apiClientVersion    string
+	apiUserAgent        string
 	bootstrapDNS        *CSVArg
 	refresh             time.Duration
 	refreshRetry        time.Duration
@@ -122,6 +125,9 @@ func parse_args() *CLIArgs {
 	flag.StringVar(&args.proxy, "proxy", "", "sets base proxy to use for all dial-outs. "+
 		"Format: <http|https|socks5|socks5h>://[login:password@]host[:port] "+
 		"Examples: http://user:password@192.168.1.1:3128, socks5://10.0.0.1:1080")
+	flag.StringVar(&args.apiClientVersion, "api-client-version", se.DefaultSESettings.ClientVersion, "client version reported to SurfEasy API")
+	flag.StringVar(&args.apiClientType, "api-client-type", se.DefaultSESettings.ClientType, "client type reported to SurfEasy API")
+	flag.StringVar(&args.apiUserAgent, "api-user-agent", se.DefaultSESettings.UserAgent, "user agent reported to SurfEasy API")
 	flag.StringVar(&args.apiLogin, "api-login", "se0316", "SurfEasy API login")
 	flag.StringVar(&args.apiPassword, "api-password", "SILrMEPBmJuhomxWkfm3JalqHX2Eheg1YhlEZiMh8II", "SurfEasy API password")
 	flag.StringVar(&args.apiAddress, "api-address", "", fmt.Sprintf("override IP address of %s", API_DOMAIN))
@@ -252,6 +258,9 @@ func run() int {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 	})
+	seclient.Settings.ClientType = args.apiClientType
+	seclient.Settings.ClientVersion = args.apiClientVersion
+	seclient.Settings.UserAgent = args.apiUserAgent
 	if err != nil {
 		mainLogger.Critical("Unable to construct SEClient: %v", err)
 		return 8

--- a/main.go
+++ b/main.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	API_DOMAIN   = "api.sec-tunnel.com"
+	API_DOMAIN   = "api2.sec-tunnel.com"
 	PROXY_SUFFIX = "sec-tunnel.com"
 )
 

--- a/seclient/seclient.go
+++ b/seclient/seclient.go
@@ -32,12 +32,12 @@ type SEEndpoints struct {
 }
 
 var DefaultSEEndpoints = SEEndpoints{
-	RegisterSubscriber:     "https://api.sec-tunnel.com/v4/register_subscriber",
-	SubscriberLogin:        "https://api.sec-tunnel.com/v4/subscriber_login",
-	RegisterDevice:         "https://api.sec-tunnel.com/v4/register_device",
-	DeviceGeneratePassword: "https://api.sec-tunnel.com/v4/device_generate_password",
-	GeoList:                "https://api.sec-tunnel.com/v4/geo_list",
-	Discover:               "https://api.sec-tunnel.com/v4/discover",
+	RegisterSubscriber:     "https://api2.sec-tunnel.com/v4/register_subscriber",
+	SubscriberLogin:        "https://api2.sec-tunnel.com/v4/subscriber_login",
+	RegisterDevice:         "https://api2.sec-tunnel.com/v4/register_device",
+	DeviceGeneratePassword: "https://api2.sec-tunnel.com/v4/device_generate_password",
+	GeoList:                "https://api2.sec-tunnel.com/v4/geo_list",
+	Discover:               "https://api2.sec-tunnel.com/v4/discover",
 }
 
 type SESettings struct {
@@ -50,9 +50,9 @@ type SESettings struct {
 }
 
 var DefaultSESettings = SESettings{
-	ClientVersion:   "Stable 74.0.3911.232",
+	ClientVersion:   "Stable 114.0.5282.21",
 	ClientType:      "se0316",
-	UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/88.0.4324.192 Safari/537.36 OPR/74.0.3911.232",
+	UserAgent:       "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 OPR/114.0.0.0",
 	DeviceName:      "Opera-Browser-Client",
 	OperatingSystem: "Windows",
 	Endpoints:       DefaultSEEndpoints,


### PR DESCRIPTION
Adds command line arguments to specify following options for API interactions:
* User agent
* Client type
* Client version

Also updates API domain used for interactions with SurfEasy API.