### PR TITLE
upstream: simplify CONNECT

### DIFF
--- a/upstream.go
+++ b/upstream.go
@@ -159,7 +159,7 @@ func (d *ProxyDialer) DialContext(ctx context.Context, network, address string) 
 	req := &http.Request{
 		Method:     PROXY_CONNECT_METHOD,
 		Proto:      "HTTP/1.1",
-		URL:        &url.URL{Opaque: dest},
+		URL:        &url.URL{Opaque: address},
 		Host:       address,
 		Header:     http.Header{
 			PROXY_HOST_HEADER: []string{address},


### PR DESCRIPTION
The replaced code is equivalent but relies on stdlib, instead. Additionally, as hinted to in `http.Request`'s documentation, instead of `http.Request.RequestURI`, I've switched to using `http.Request.URL`. `http.Request.ProtoMajor` (1) and `http.Request.ProtoMinor` (1) are implicitly already set with `http.Request.Proto` (http/1.1), so that is removed, too.

Unsure if the previous code works around any bug or desires some peculiar behaviour absent in stdlib. But if it doesn't, then there might be merit in simplifying as the PR does.

I've tested its parent patch ([link](https://github.com/celzero/firestack/commit/507523e19d8f9b7dafe16ac54188613d0d5070e7)) locally and in [Rethink](https://github.com/celzero/rethink-app), our Android app (which now uses `opera-proxy`), and things work just like before.