### PR TITLE
implement socks listener (socks-mode)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ eu3.sec-tunnel.com,77.111.244.22,443
 | api-login | String | SurfEasy API login (default "se0316") |
 | api-password | String | SurfEasy API password (default "SILrMEPBmJuhomxWkfm3JalqHX2Eheg1YhlEZiMh8II") |
 | api-user-agent | String | user agent reported to SurfEasy API (default "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0 Safari/537.36 OPR/114.0.0.0") |
-| bind-address | String | HTTP proxy listen address (default "127.0.0.1:18080") |
+| bind-address | String | proxy listen address (default "127.0.0.1:18080") |
 | bootstrap-dns | String | Comma-separated list of DNS/DoH/DoT/DoQ resolvers for initial discovery of SurfEasy API address. See https://github.com/ameshkov/dnslookup/ for upstream DNS URL format. Examples: `https://1.1.1.1/dns-query`, `quic://dns.adguard.com`  (default `https://1.1.1.3/dns-query,https://8.8.8.8/dns-query,https://dns.google/dns-query,https://security.cloudflare-dns.com/dns-query,https://fidelity.vm-0.com/q,https://wikimedia-dns.org/dns-query,https://dns.adguard-dns.com/dns-query,https://dns.quad9.net/dns-query,https://doh.cleanbrowsing.org/doh/adult-filter/`) |
 | cafile | String | use custom CA certificate bundle file |
 | certchain-workaround | Boolean | add bundled cross-signed intermediate cert to certchain to make it check out on old systems (default true) |
@@ -112,6 +112,7 @@ eu3.sec-tunnel.com,77.111.244.22,443
 | timeout | Duration | timeout for network operations (default 10s) |
 | verbosity | Number | logging verbosity (10 - debug, 20 - info, 30 - warning, 40 - error, 50 - critical) (default 20) |
 | version | - | show program version and exit |
+| socks-mode | - | listen for SOCKS requests instead of HTTP |
 
 ## See also
 

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ toolchain go1.24.2
 require (
 	github.com/AdguardTeam/dnsproxy v0.75.2
 	github.com/Snawoot/go-http-digest-auth-client v1.1.3
+	github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5
 	github.com/hashicorp/go-multierror v1.1.1
 	golang.org/x/net v0.38.0
 )

--- a/go.sum
+++ b/go.sum
@@ -8,6 +8,8 @@ github.com/ameshkov/dnscrypt/v2 v2.4.0 h1:if6ZG2cuQmcP2TwSY+D0+8+xbPfoatufGlOQTM
 github.com/ameshkov/dnscrypt/v2 v2.4.0/go.mod h1:WpEFV2uhebXb8Jhes/5/fSdpmhGV8TL22RDaeWwV6hI=
 github.com/ameshkov/dnsstamps v1.0.3 h1:Srzik+J9mivH1alRACTbys2xOxs0lRH9qnTA7Y1OYVo=
 github.com/ameshkov/dnsstamps v1.0.3/go.mod h1:Ii3eUu73dx4Vw5O4wjzmT5+lkCwovjzaEZZ4gKyIH5A=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=
+github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=

--- a/handler/socks.go
+++ b/handler/socks.go
@@ -1,0 +1,17 @@
+package handler
+
+import (
+	"github.com/Snawoot/opera-proxy/dialer"
+	"github.com/armon/go-socks5"
+	"log"
+)
+
+func NewSocksServer(dialer dialer.ContextDialer, logger *log.Logger) (*socks5.Server, error) {
+	return socks5.New(&socks5.Config{
+		Rules: &socks5.PermitCommand{
+			EnableConnect: true,
+		},
+		Logger: logger,
+		Dial:   dialer.DialContext,
+	})
+}


### PR DESCRIPTION
This patch lets users listen for SOCKS requests instead of HTTP, as discussed in #68.
Some duplicated issues: #15, #26